### PR TITLE
Fix checklist rendering conditions in inspection detail

### DIFF
--- a/client/src/pages/InspectionDetail.tsx
+++ b/client/src/pages/InspectionDetail.tsx
@@ -28,11 +28,11 @@ import {
 import type { Inspection } from "@shared/schema";
 
 export default function InspectionDetail() {
-  const [match, params] = useRoute('/inspections/:id');
+  const [match, params] = useRoute<{ id: string }>('/inspections/:id');
   const [, setLocation] = useLocation();
   const { user } = useAuth();
   const queryClient = useQueryClient();
-  const inspectionId = params?.id;
+  const inspectionId = params ? params.id : undefined;
 
   const { data: inspection, isLoading, error } = useQuery<Inspection>({
     queryKey: ['/api/inspections', inspectionId],
@@ -147,6 +147,8 @@ export default function InspectionDetail() {
       </div>
     );
   }
+
+  const hasChecklistItems = Array.isArray(inspection.checklist) && inspection.checklist.length > 0;
 
   return (
     <TooltipProvider>
@@ -353,7 +355,7 @@ export default function InspectionDetail() {
               </CardTitle>
             </CardHeader>
             <CardContent>
-              {inspection.checklist ? (
+              {hasChecklistItems ? (
                 <div className="space-y-4">
                   <div className="flex items-center space-x-2 p-3 bg-green-50 border border-green-200 rounded-lg">
                     <CheckCircle2 className="w-5 h-5 text-green-600" />


### PR DESCRIPTION
## Summary
- ensure the inspection detail route parameters are typed to avoid null/never access
- check that inspection.checklist is a non-empty array before treating it as an active template
- keep the template selection prompt visible when no checklist items are present

## Testing
- npm run check *(fails: existing TypeScript errors in other modules such as AcceptInvite.tsx, Inspections.tsx, Reports.tsx, Users.tsx, analytics services, export services, openai assistants, and storage)*

------
https://chatgpt.com/codex/tasks/task_e_68ca1b6d02348320b2c628907e05853a