### PR TITLE
Handle query params in query client

### DIFF
--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -74,17 +74,23 @@ export const getQueryFn: (options: { on401: UnauthorizedBehavior }) => QueryFunc
     let url = "";
 
     pathSegments.forEach((segment, index) => {
+      const normalizedSegment = segment.replace(/^\/+/, "");
+
       if (index === 0) {
-        url = segment;
+        if (/^https?:\/\//.test(segment)) {
+          url = segment;
+        } else if (segment.startsWith("/")) {
+          url = segment;
+        } else {
+          url = `/${normalizedSegment}`;
+        }
         return;
       }
 
-      const normalizedSegment = segment.replace(/^\/+/, "");
-      if (url.endsWith("/")) {
-        url = `${url}${normalizedSegment}`;
-      } else {
-        url = `${url}/${normalizedSegment}`;
+      if (!url.endsWith("/")) {
+        url += "/";
       }
+      url += normalizedSegment;
     });
 
     const searchParams = new URLSearchParams();

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -48,13 +48,48 @@ type UnauthorizedBehavior = "returnNull" | "throw";
 export const getQueryFn: (options: { on401: UnauthorizedBehavior }) => QueryFunction<any> =
   ({ on401: unauthorizedBehavior }) =>
   async ({ queryKey }) => {
-    const [url, ...paramObjects] = queryKey as [string, ...Array<Record<string, unknown>>];
+    const parts = queryKey as ReadonlyArray<unknown>;
+
+    const pathSegments: string[] = [];
+    const paramObjects: Array<Record<string, unknown>> = [];
+
+    for (const part of parts) {
+      if (part === null || part === undefined) {
+        continue;
+      }
+
+      if (typeof part === "string" || typeof part === "number") {
+        const segment = String(part);
+        if (segment) {
+          pathSegments.push(segment);
+        }
+        continue;
+      }
+
+      if (!Array.isArray(part) && typeof part === "object") {
+        paramObjects.push(part as Record<string, unknown>);
+      }
+    }
+
+    let url = "";
+
+    pathSegments.forEach((segment, index) => {
+      if (index === 0) {
+        url = segment;
+        return;
+      }
+
+      const normalizedSegment = segment.replace(/^\/+/, "");
+      if (url.endsWith("/")) {
+        url = `${url}${normalizedSegment}`;
+      } else {
+        url = `${url}/${normalizedSegment}`;
+      }
+    });
 
     const searchParams = new URLSearchParams();
 
     for (const params of paramObjects) {
-      if (!params || typeof params !== "object") continue;
-
       for (const [key, value] of Object.entries(params)) {
         if (value === undefined) continue;
 

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -48,7 +48,31 @@ type UnauthorizedBehavior = "returnNull" | "throw";
 export const getQueryFn: (options: { on401: UnauthorizedBehavior }) => QueryFunction<any> =
   ({ on401: unauthorizedBehavior }) =>
   async ({ queryKey }) => {
-    const res = await fetch(queryKey.join("/") as string, {
+    const [url, ...paramObjects] = queryKey as [string, ...Array<Record<string, unknown>>];
+
+    const searchParams = new URLSearchParams();
+
+    for (const params of paramObjects) {
+      if (!params || typeof params !== "object") continue;
+
+      for (const [key, value] of Object.entries(params)) {
+        if (value === undefined) continue;
+
+        if (Array.isArray(value)) {
+          for (const item of value) {
+            if (item === undefined) continue;
+            searchParams.append(key, String(item));
+          }
+        } else {
+          searchParams.append(key, String(value));
+        }
+      }
+    }
+
+    const queryString = searchParams.toString();
+    const requestUrl = queryString ? `${url}?${queryString}` : url;
+
+    const res = await fetch(requestUrl, {
       credentials: "include",
     });
 


### PR DESCRIPTION
## Summary
- parse query keys as tuples and separate the URL path from parameter objects
- construct query strings from provided parameters while ignoring undefined values
- fetch API resources with the correct query string so filtered endpoints reload properly

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7fc1b71b8832085cd6a5fa17d2f35