### PR TITLE
Use mutation for deleting inspections

### DIFF
--- a/client/src/pages/Inspections.tsx
+++ b/client/src/pages/Inspections.tsx
@@ -61,23 +61,22 @@ export default function Inspections() {
       });
   };
 
-  const handleDeleteInspection = async (id: string) => {
-    try {
-      const response = await fetch(`/api/inspections/${id}`, {
-        method: 'DELETE'
-      });
-      
-      if (response.ok) {
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => apiRequest(`/api/inspections/${id}`, 'DELETE'),
+  });
+
+  const handleDeleteInspection = (id: string) => {
+    deleteMutation.mutate(id, {
+      onSuccess: () => {
         setInspections(prev => prev.filter(inspection => inspection.id !== id));
         setShowDeleteModal(null);
         alert('Inspeção excluída com sucesso!');
-      } else {
-        throw new Error('Erro ao excluir inspeção');
-      }
-    } catch (error) {
-      console.error('Erro ao excluir inspeção:', error);
-      alert('Erro ao excluir inspeção. Tente novamente.');
-    }
+      },
+      onError: (error) => {
+        console.error('Erro ao excluir inspeção:', error);
+        alert('Erro ao excluir inspeção. Tente novamente.');
+      },
+    });
   };
 
   const handleCloneInspection = async (id: string, title: string) => {


### PR DESCRIPTION
## Summary
- create a dedicated delete mutation for inspections using apiRequest
- wire the delete modal to trigger the mutation with success and error handlers
- disable the confirm button based on the mutation pending state

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7eb2948908320ba0fb5414e84a995