### PR TITLE
Fix resend invitation API call

### DIFF
--- a/client/src/pages/Users.tsx
+++ b/client/src/pages/Users.tsx
@@ -147,17 +147,19 @@ export default function Users() {
 
   const resendInvitation = async (invitationId: string) => {
     try {
-      await apiRequest('POST', `/api/invitations/${invitationId}/resend`);
+      const result = await apiRequest(`/api/invitations/${invitationId}/resend`, 'POST');
       toast({
         title: "Convite reenviado!",
         description: "O convite foi enviado novamente por email",
       });
+      return result;
     } catch (error) {
       toast({
         title: "Erro ao reenviar convite",
         description: (error as Error).message,
         variant: "destructive"
       });
+      throw error;
     }
   };
 


### PR DESCRIPTION
## Summary
- update the resend invitation helper to call the API with the correct argument order
- return the resolved API response while keeping success and error toast handling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7eb2aa7408320a749c80672bbd2eb