### PR TITLE
Fix apiRequest usage for invitations and users

### DIFF
--- a/client/src/components/Organizations/InviteUserDialog.tsx
+++ b/client/src/components/Organizations/InviteUserDialog.tsx
@@ -48,8 +48,7 @@ export default function InviteUserDialog({ organizationId, trigger }: InviteUser
 
   const inviteUserMutation = useMutation({
     mutationFn: async (data: InviteUserData) => {
-      const response = await apiRequest('POST', '/api/invitations', data);
-      return response.json();
+      return apiRequest('/api/invitations', 'POST', data);
     },
     onSuccess: (invitation) => {
       // Generate invite link

--- a/client/src/pages/Users.tsx
+++ b/client/src/pages/Users.tsx
@@ -52,8 +52,7 @@ export default function Users() {
 
   const updateUserMutation = useMutation({
     mutationFn: async ({ userId, updates }: { userId: string; updates: Partial<User> }) => {
-      const response = await apiRequest(`/api/users/${userId}`, 'PATCH', updates);
-      return response.json();
+      return apiRequest(`/api/users/${userId}`, 'PATCH', updates);
     },
     onSuccess: (updatedUser) => {
       toast({
@@ -73,8 +72,7 @@ export default function Users() {
 
   const deleteInvitationMutation = useMutation({
     mutationFn: async (invitationId: string) => {
-      const response = await apiRequest(`/api/invitations/${invitationId}`, 'DELETE');
-      return response.json();
+      return apiRequest(`/api/invitations/${invitationId}`, 'DELETE');
     },
     onSuccess: () => {
       toast({
@@ -147,7 +145,7 @@ export default function Users() {
 
   const resendInvitation = async (invitationId: string) => {
     try {
-      await apiRequest('POST', `/api/invitations/${invitationId}/resend`);
+      await apiRequest(`/api/invitations/${invitationId}/resend`, 'POST');
       toast({
         title: "Convite reenviado!",
         description: "O convite foi enviado novamente por email",


### PR DESCRIPTION
## Summary
- update the invite user dialog to call `apiRequest` with the URL-first signature and use its parsed response
- adjust user management mutations to use the same signature and rely on the returned data directly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7eb5b66248320bf83f7b230940447