### PR TITLE
Refactor routing layout to prevent repeated remounts

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,30 +1,30 @@
 import { Switch, Route } from "wouter";
-import { queryClient } from "./lib/queryClient";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { useAuth } from "./hooks/useAuth";
-import Dashboard from "@/pages/Dashboard";
-import Organizations from "@/pages/Organizations";
-import Inspections from "@/pages/Inspections";
-import ActionPlans from "@/pages/ActionPlans";
-import Reports from "@/pages/Reports";
-import Users from "@/pages/Users";
-import ChecklistTemplates from "@/pages/ChecklistTemplates";
-import NewChecklistTemplate from "@/pages/NewChecklistTemplate";
-import ChecklistDetail from "@/pages/ChecklistDetail";
-import ChecklistEdit from "@/pages/ChecklistEdit";
-import CSVImport from "@/pages/CSVImport";
-import AIChecklistGenerator from "@/pages/AIChecklistGenerator";
-import NewInspection from "@/pages/NewInspection";
-import InspectionDetail from "@/pages/InspectionDetail";
-import Companies from "@/pages/Companies";
-import CompanyForm from "@/pages/CompanyForm";
-import AcceptInvite from "@/pages/AcceptInvite";
-import NotFound from "@/pages/not-found";
 import Sidebar from "@/components/Layout/Sidebar";
 import TopBar from "@/components/Layout/TopBar";
 import AIChatbot from "@/components/AIChatbot";
+import ActionPlans from "@/pages/ActionPlans";
+import Companies from "@/pages/Companies";
+import CompanyForm from "@/pages/CompanyForm";
+import Dashboard from "@/pages/Dashboard";
+import InspectionDetail from "@/pages/InspectionDetail";
+import Inspections from "@/pages/Inspections";
+import ChecklistDetail from "@/pages/ChecklistDetail";
+import ChecklistEdit from "@/pages/ChecklistEdit";
+import ChecklistTemplates from "@/pages/ChecklistTemplates";
+import NewChecklistTemplate from "@/pages/NewChecklistTemplate";
+import NewInspection from "@/pages/NewInspection";
+import Organizations from "@/pages/Organizations";
+import Reports from "@/pages/Reports";
+import Users from "@/pages/Users";
+import CSVImport from "@/pages/CSVImport";
+import AIChecklistGenerator from "@/pages/AIChecklistGenerator";
+import AcceptInvite from "@/pages/AcceptInvite";
+import NotFound from "@/pages/not-found";
+import { queryClient } from "./lib/queryClient";
+import { useAuth } from "./hooks/useAuth";
 
 function AppLayout({ children }: { children: React.ReactNode }) {
   const { user } = useAuth();
@@ -54,30 +54,40 @@ function AppLayout({ children }: { children: React.ReactNode }) {
   );
 }
 
+function AuthenticatedRoutes() {
+  return (
+    <AppLayout>
+      <Switch>
+        <Route path="/" component={Dashboard} />
+        <Route path="/dashboard" component={Dashboard} />
+        <Route path="/organizations" component={Organizations} />
+        <Route path="/inspections" component={Inspections} />
+        <Route path="/inspections/new" component={NewInspection} />
+        <Route path="/inspections/:id" component={InspectionDetail} />
+        <Route path="/checklists" component={ChecklistTemplates} />
+        <Route path="/checklist-templates" component={ChecklistTemplates} />
+        <Route path="/checklists/new" component={NewChecklistTemplate} />
+        <Route path="/checklists/import" component={CSVImport} />
+        <Route path="/checklists/ai-generator" component={AIChecklistGenerator} />
+        <Route path="/checklists/:id/edit" component={ChecklistEdit} />
+        <Route path="/checklists/:id" component={ChecklistDetail} />
+        <Route path="/action-plans" component={ActionPlans} />
+        <Route path="/reports" component={Reports} />
+        <Route path="/users" component={Users} />
+        <Route path="/companies" component={Companies} />
+        <Route path="/companies/new" component={CompanyForm} />
+        <Route path="/companies/:id/edit" component={CompanyForm} />
+        <Route component={NotFound} />
+      </Switch>
+    </AppLayout>
+  );
+}
+
 function Router() {
   return (
     <Switch>
       <Route path="/accept-invite" component={AcceptInvite} />
-      <Route path="/" component={() => <AppLayout><Dashboard /></AppLayout>} />
-      <Route path="/dashboard" component={() => <AppLayout><Dashboard /></AppLayout>} />
-      <Route path="/organizations" component={() => <AppLayout><Organizations /></AppLayout>} />
-      <Route path="/inspections" component={() => <AppLayout><Inspections /></AppLayout>} />
-      <Route path="/inspections/new" component={() => <AppLayout><NewInspection /></AppLayout>} />
-      <Route path="/inspections/:id" component={() => <AppLayout><InspectionDetail /></AppLayout>} />
-      <Route path="/checklists" component={() => <AppLayout><ChecklistTemplates /></AppLayout>} />
-      <Route path="/checklist-templates" component={() => <AppLayout><ChecklistTemplates /></AppLayout>} />
-      <Route path="/checklists/new" component={() => <AppLayout><NewChecklistTemplate /></AppLayout>} />
-      <Route path="/checklists/import" component={() => <AppLayout><CSVImport /></AppLayout>} />
-      <Route path="/checklists/ai-generator" component={() => <AppLayout><AIChecklistGenerator /></AppLayout>} />
-      <Route path="/checklists/:id/edit" component={() => <AppLayout><ChecklistEdit /></AppLayout>} />
-      <Route path="/checklists/:id" component={() => <AppLayout><ChecklistDetail /></AppLayout>} />
-      <Route path="/action-plans" component={() => <AppLayout><ActionPlans /></AppLayout>} />
-      <Route path="/reports" component={() => <AppLayout><Reports /></AppLayout>} />
-      <Route path="/users" component={() => <AppLayout><Users /></AppLayout>} />
-      <Route path="/companies" component={() => <AppLayout><Companies /></AppLayout>} />
-      <Route path="/companies/new" component={() => <AppLayout><CompanyForm /></AppLayout>} />
-      <Route path="/companies/:id/edit" component={() => <AppLayout><CompanyForm /></AppLayout>} />
-      <Route component={NotFound} />
+      <Route component={AuthenticatedRoutes} />
     </Switch>
   );
 }


### PR DESCRIPTION
## Summary
- refactor the authenticated routing tree to render within a single AppLayout wrapper
- avoid recreating inline route components that caused inspection detail to remount repeatedly
- keep the accept invite flow outside of the authenticated layout while leaving the not found fallback intact

## Testing
- npm run check *(fails: pre-existing TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d7fdefa7388320910186ddd8ada1f7