### PR TITLE
Implement storage normalizers and resolve type checks

### DIFF
--- a/client/src/pages/AcceptInvite.tsx
+++ b/client/src/pages/AcceptInvite.tsx
@@ -322,7 +322,7 @@ export default function AcceptInvite() {
                 <div className="pt-4">
                   <Button
                     type="submit"
-                    disabled={acceptInviteMutation.isPending || isValidToken === false || !token}
+                    disabled={acceptInviteMutation.isPending || isValidToken !== true || !token}
                     className="w-full bg-compia-blue hover:bg-compia-blue/90 text-primary-foreground"
                     data-testid="accept-invitation-button"
                   >

--- a/client/src/pages/InspectionDetail.tsx
+++ b/client/src/pages/InspectionDetail.tsx
@@ -28,11 +28,11 @@ import {
 import type { Inspection } from "@shared/schema";
 
 export default function InspectionDetail() {
-  const [match, params] = useRoute('/inspections/:id');
+  const [match, params] = useRoute<{ id: string }>('/inspections/:id');
   const [, setLocation] = useLocation();
   const { user } = useAuth();
   const queryClient = useQueryClient();
-  const inspectionId = params?.id;
+  const inspectionId = params ? params.id : undefined;
 
   const { data: inspection, isLoading, error } = useQuery<Inspection>({
     queryKey: ['/api/inspections', inspectionId],

--- a/client/src/pages/Inspections.tsx
+++ b/client/src/pages/Inspections.tsx
@@ -39,6 +39,7 @@ export default function Inspections() {
 
   const [inspections, setInspections] = useState<Inspection[]>([]);
   const [loading, setLoading] = useState(true);
+  const [deleteLoading, setDeleteLoading] = useState(false);
   const [, setLocation] = useLocation();
 
   useEffect(() => {
@@ -63,6 +64,7 @@ export default function Inspections() {
 
   const handleDeleteInspection = async (id: string) => {
     try {
+      setDeleteLoading(true);
       const response = await fetch(`/api/inspections/${id}`, {
         method: 'DELETE'
       });
@@ -77,6 +79,8 @@ export default function Inspections() {
     } catch (error) {
       console.error('Erro ao excluir inspeção:', error);
       alert('Erro ao excluir inspeção. Tente novamente.');
+    } finally {
+      setDeleteLoading(false);
     }
   };
 
@@ -373,10 +377,10 @@ export default function Inspections() {
               <Button variant="outline" onClick={() => setShowDeleteModal(null)}>
                 Cancelar
               </Button>
-              <Button 
-                variant="destructive" 
+              <Button
+                variant="destructive"
                 onClick={() => handleDeleteInspection(showDeleteModal)}
-                disabled={deleteMutation.isPending}
+                disabled={deleteLoading}
               >
                 Excluir
               </Button>

--- a/client/src/pages/Reports.tsx
+++ b/client/src/pages/Reports.tsx
@@ -12,6 +12,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useAuth, hasPermission } from "@/hooks/useAuth";
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, PieChart as RechartsPieChart, Pie, Cell, Legend, BarChart, Bar } from "recharts";
 import type { DashboardStats, ComplianceReport, InspectionReport } from "@/lib/types";
+import type { Organization } from "@shared/schema";
 
 const COLORS = ['#3B82F6', '#8B5CF6', '#10B981', '#F59E0B', '#EF4444'];
 
@@ -25,7 +26,7 @@ export default function Reports() {
     queryKey: ['/api/dashboard/stats', { organizationId: selectedOrganization !== "all" ? selectedOrganization : undefined }],
   });
 
-  const { data: organizations } = useQuery({
+  const { data: organizations } = useQuery<Organization[]>({
     queryKey: ['/api/organizations'],
   });
 

--- a/client/src/pages/Users.tsx
+++ b/client/src/pages/Users.tsx
@@ -14,6 +14,7 @@ import { apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
 import { useAuth, hasPermission } from "@/hooks/useAuth";
 import type { User, UserWithOrganization, Invitation, InvitationWithDetails } from "@/lib/types";
+import type { Organization } from "@shared/schema";
 import { ROLE_LABELS } from "@/lib/constants";
 import InviteUserDialog from "@/components/Organizations/InviteUserDialog";
 import { 
@@ -42,7 +43,7 @@ export default function Users() {
     queryKey: ['/api/invitations', { organizationId: selectedOrganization !== "all" ? selectedOrganization : undefined }],
   });
 
-  const { data: organizations } = useQuery({
+  const { data: organizations } = useQuery<Organization[]>({
     queryKey: ['/api/organizations'],
     enabled: user.role === 'system_admin'
   });

--- a/server/services/analytics.ts
+++ b/server/services/analytics.ts
@@ -244,12 +244,13 @@ export function generateTrendAnalysis(data: any[], period: string): any {
   }, {} as Record<string, any[]>);
   
   // Calculate metrics for each period
-  Object.entries(grouped).forEach(([key, items]) => {
+  Object.entries(grouped as Record<string, any[]>).forEach(([key, items]) => {
+    const groupItems = items as any[];
     const periodData = {
       period: key,
-      count: items.length,
-      compliance: calculateComplianceForItems(items),
-      avgResolutionTime: calculateAvgResolutionTime(items)
+      count: groupItems.length,
+      compliance: calculateComplianceForItems(groupItems),
+      avgResolutionTime: calculateAvgResolutionTime(groupItems)
     };
     
     if (period === 'daily') trends.daily.push(periodData);

--- a/server/services/export.ts
+++ b/server/services/export.ts
@@ -455,7 +455,11 @@ COMPIA - Sistema Inteligente de Segurança do Trabalho
     `;
   } else if (type === "action-plan") {
     const plan = data as ActionPlan;
-    
+    const tasks = (plan as unknown as { tasks?: any[] }).tasks ?? [];
+    const formattedTasks = tasks
+      .map(task => `[ ${task.isCompleted ? 'X' : ' '} ] ${task.title}\n    ${task.description || ''}`)
+      .join('\n\n');
+
     content = `
 PLANO DE AÇÃO - METODOLOGIA 5W2H
 
@@ -467,7 +471,7 @@ ID do Plano: ${plan.id}
 Título: ${plan.title}
 Prioridade: ${plan.priority}
 Status: ${plan.status}
-Responsável: ${plan.assigneeId}
+Responsável: ${plan.assignedTo ?? 'Não definido'}
 
 WHAT (O QUÊ)
 ------------
@@ -500,9 +504,7 @@ ${plan.howMuch}
 
 TAREFAS
 -------
-${(plan.tasks as any[] || []).map((task: any) => 
-  `[ ${task.isCompleted ? 'X' : ' '} ] ${task.title}\n    ${task.description || ''}`
-).join('\n\n')}
+${formattedTasks}
 
 ================================================================================
 Documento gerado em ${new Date().toLocaleDateString('pt-BR')} às ${new Date().toLocaleTimeString('pt-BR')}

--- a/server/services/openai-assistants.ts
+++ b/server/services/openai-assistants.ts
@@ -316,11 +316,11 @@ export class OpenAIAssistantsService {
       });
 
       // Wait for completion
-      let runStatus = await this.client.beta.threads.runs.retrieve(thread.id, run.id);
+      let runStatus = await this.client.beta.threads.runs.retrieve(run.id, { thread_id: thread.id });
       let attempts = 0;
       while (runStatus.status !== 'completed' && runStatus.status !== 'failed' && attempts < 30) {
         await new Promise(resolve => setTimeout(resolve, 1000));
-        runStatus = await this.client.beta.threads.runs.retrieve(thread.id, run.id);
+        runStatus = await this.client.beta.threads.runs.retrieve(run.id, { thread_id: thread.id });
         attempts++;
       }
 

--- a/server/storage-normalizers.ts
+++ b/server/storage-normalizers.ts
@@ -1,0 +1,376 @@
+import { randomUUID } from "crypto";
+import {
+  type InsertOrganization,
+  type InsertUser,
+  type InsertInvitation,
+  type InsertInspection,
+  type InsertActionPlan,
+  type InsertFile,
+  type InsertChecklistTemplate,
+  type InsertChecklistFolder,
+  type InsertActivityLog,
+  type InsertCompany,
+  type InsertCompanyLocation
+} from "@shared/schema";
+
+const INVITATION_EXPIRATION_DAYS = 7;
+
+type PreparedRecord = Record<string, unknown>;
+
+const sanitizeRecord = <T extends Record<string, unknown>>(record: T): T => {
+  const result: Record<string, unknown> = { ...record };
+  for (const key of Object.keys(result)) {
+    if (result[key] === undefined) {
+      delete result[key];
+    }
+  }
+  return result as T;
+};
+
+const toOptionalDate = (value: unknown): Date | null | undefined => {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  if (value instanceof Date) return value;
+  const parsed = new Date(value as string | number);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+};
+
+const toDateOrNow = (value: unknown): Date => {
+  const parsed = toOptionalDate(value);
+  return parsed ?? new Date();
+};
+
+const toOptionalNumber = (value: unknown): number | null | undefined => {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  if (typeof value === "number") return Number.isNaN(value) ? undefined : value;
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    return Number.isNaN(parsed) ? undefined : parsed;
+  }
+  return undefined;
+};
+
+const ensureArray = <T>(value: unknown, fallback: T): T => {
+  if (Array.isArray(value)) {
+    return value as T;
+  }
+  return fallback;
+};
+
+const ensureObject = (value: unknown): Record<string, unknown> => {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return {};
+};
+
+const addDays = (base: Date, days: number): Date => {
+  return new Date(base.getTime() + days * 24 * 60 * 60 * 1000);
+};
+
+export function prepareOrganization(organization: InsertOrganization): PreparedRecord {
+  const org = organization as Record<string, any>;
+  const now = new Date();
+  const maxUsers = toOptionalNumber(org.maxUsers);
+  const maxSubsidiaries = toOptionalNumber(org.maxSubsidiaries);
+
+  const prepared: PreparedRecord = {
+    id: org.id ?? randomUUID(),
+    name: org.name,
+    type: org.type,
+    parentId: org.parentId ?? null,
+    plan: org.plan ?? "basic",
+    maxUsers: typeof maxUsers === "number" ? maxUsers : 10,
+    maxSubsidiaries: typeof maxSubsidiaries === "number" ? maxSubsidiaries : 3,
+    isActive: typeof org.isActive === "boolean" ? org.isActive : true,
+    address: org.address ?? null,
+    phone: org.phone ?? null,
+    email: org.email ?? null,
+    cnpj: org.cnpj ?? null,
+    createdAt: toOptionalDate(org.createdAt) ?? now,
+    updatedAt: toOptionalDate(org.updatedAt) ?? now
+  };
+
+  return sanitizeRecord(prepared);
+}
+
+export function prepareUser(user: InsertUser): PreparedRecord {
+  const userData = user as Record<string, any>;
+  const now = new Date();
+
+  const prepared: PreparedRecord = {
+    id: userData.id ?? randomUUID(),
+    email: userData.email,
+    name: userData.name,
+    role: userData.role,
+    organizationId: userData.organizationId ?? null,
+    isActive: typeof userData.isActive === "boolean" ? userData.isActive : true,
+    lastLoginAt: toOptionalDate(userData.lastLoginAt) ?? null,
+    createdAt: toOptionalDate(userData.createdAt) ?? now,
+    updatedAt: toOptionalDate(userData.updatedAt) ?? now
+  };
+
+  return sanitizeRecord(prepared);
+}
+
+export function prepareInvitation(invitation: InsertInvitation): PreparedRecord {
+  const invitationData = invitation as Record<string, any>;
+  const now = new Date();
+
+  const prepared: PreparedRecord = {
+    id: invitationData.id ?? randomUUID(),
+    email: invitationData.email,
+    role: invitationData.role,
+    organizationId: invitationData.organizationId,
+    invitedBy: invitationData.invitedBy,
+    token: invitationData.token ?? randomUUID(),
+    isAccepted: typeof invitationData.isAccepted === "boolean" ? invitationData.isAccepted : false,
+    expiresAt: toOptionalDate(invitationData.expiresAt) ?? addDays(now, INVITATION_EXPIRATION_DAYS),
+    createdAt: toOptionalDate(invitationData.createdAt) ?? now
+  };
+
+  return sanitizeRecord(prepared);
+}
+
+export function prepareInspection(inspection: InsertInspection): PreparedRecord {
+  const inspectionData = inspection as Record<string, any>;
+  const now = new Date();
+  const latitude = toOptionalNumber(inspectionData.latitude);
+  const longitude = toOptionalNumber(inspectionData.longitude);
+  const status = inspectionData.status ?? "draft";
+  const inspectorId = inspectionData.inspectorId ?? "admin-id";
+  const description = inspectionData.description ?? null;
+  const recommendations = inspectionData.recommendations ?? null;
+  const priority = inspectionData.priority ?? "medium";
+
+  const prepared: PreparedRecord = {
+    id: inspectionData.id ?? randomUUID(),
+    title: inspectionData.title,
+    description,
+    location: inspectionData.location,
+    status,
+    organizationId: inspectionData.organizationId,
+    inspectorId,
+    checklistTemplateId: inspectionData.checklistTemplateId ?? null,
+    checklist: ensureArray(inspectionData.checklist, [] as unknown[]),
+    findings: ensureArray(inspectionData.findings, [] as unknown[]),
+    recommendations,
+    aiAnalysis: inspectionData.aiAnalysis ?? null,
+    qrCode: inspectionData.qrCode ?? null,
+    scheduledAt: toOptionalDate(inspectionData.scheduledAt) ?? null,
+    startedAt: toOptionalDate(inspectionData.startedAt) ?? null,
+    completedAt: toOptionalDate(inspectionData.completedAt) ?? null,
+    createdAt: toOptionalDate(inspectionData.createdAt) ?? now,
+    updatedAt: toOptionalDate(inspectionData.updatedAt) ?? now,
+    priority,
+    companyName: inspectionData.companyName ?? null,
+    zipCode: inspectionData.zipCode ?? null,
+    fullAddress: inspectionData.fullAddress ?? null,
+    latitude: latitude ?? null,
+    longitude: longitude ?? null,
+    technicianName: inspectionData.technicianName ?? null,
+    technicianEmail: inspectionData.technicianEmail ?? null,
+    companyResponsibleName: inspectionData.companyResponsibleName ?? null,
+    aiAssistantId: inspectionData.aiAssistantId ?? "GENERAL",
+    actionPlanType: inspectionData.actionPlanType ?? "5W2H"
+  };
+
+  return sanitizeRecord(prepared);
+}
+
+export function prepareActionPlan(actionPlan: InsertActionPlan): PreparedRecord {
+  const actionPlanData = actionPlan as Record<string, any>;
+  const now = new Date();
+
+  const prepared: PreparedRecord = {
+    id: actionPlanData.id ?? randomUUID(),
+    inspectionId: actionPlanData.inspectionId,
+    title: actionPlanData.title,
+    description: actionPlanData.description ?? null,
+    what: actionPlanData.what,
+    why: actionPlanData.why,
+    where: actionPlanData.where,
+    when: toDateOrNow(actionPlanData.when),
+    who: actionPlanData.who,
+    how: actionPlanData.how,
+    howMuch: actionPlanData.howMuch ?? null,
+    status: actionPlanData.status ?? "pending",
+    priority: actionPlanData.priority ?? "medium",
+    organizationId: actionPlanData.organizationId,
+    assignedTo: actionPlanData.assignedTo ?? null,
+    dueDate: toOptionalDate(actionPlanData.dueDate) ?? null,
+    completedAt: toOptionalDate(actionPlanData.completedAt) ?? null,
+    createdAt: toOptionalDate(actionPlanData.createdAt) ?? now,
+    updatedAt: toOptionalDate(actionPlanData.updatedAt) ?? now
+  };
+
+  return sanitizeRecord(prepared);
+}
+
+export function prepareFile(file: InsertFile): PreparedRecord {
+  const fileData = file as Record<string, any>;
+  const now = new Date();
+  const size = typeof fileData.size === "number" ? fileData.size : Number(fileData.size);
+
+  const prepared: PreparedRecord = {
+    id: fileData.id ?? randomUUID(),
+    name: fileData.name,
+    type: fileData.type,
+    size: Number.isNaN(size) ? 0 : size,
+    url: fileData.url,
+    inspectionId: fileData.inspectionId ?? null,
+    actionPlanId: fileData.actionPlanId ?? null,
+    organizationId: fileData.organizationId,
+    uploadedBy: fileData.uploadedBy,
+    createdAt: toOptionalDate(fileData.createdAt) ?? now
+  };
+
+  return sanitizeRecord(prepared);
+}
+
+export function prepareChecklistTemplate(template: InsertChecklistTemplate): PreparedRecord {
+  const templateData = template as Record<string, any>;
+  const now = new Date();
+  const items = ensureArray(templateData.items, [] as unknown[]);
+  const rawTags = templateData.tags;
+  const tags = Array.isArray(rawTags)
+    ? rawTags.map(tag => String(tag))
+    : rawTags != null
+      ? [String(rawTags)]
+      : [];
+
+  const prepared: PreparedRecord = {
+    id: templateData.id ?? randomUUID(),
+    name: templateData.name,
+    description: templateData.description ?? null,
+    category: templateData.category,
+    folderId: templateData.folderId ?? null,
+    organizationId: templateData.organizationId,
+    items,
+    tags: tags.length > 0 ? tags : [],
+    version: (templateData.version as number | undefined) ?? 1,
+    parentTemplateId: templateData.parentTemplateId ?? null,
+    isActive: typeof templateData.isActive === "boolean" ? templateData.isActive : true,
+    isDefault: typeof templateData.isDefault === "boolean" ? templateData.isDefault : false,
+    isPublic: typeof templateData.isPublic === "boolean" ? templateData.isPublic : false,
+    parentCategoryId: templateData.parentCategoryId ?? null,
+    categoryPath: templateData.categoryPath ?? null,
+    isCategoryFolder: typeof templateData.isCategoryFolder === "boolean" ? templateData.isCategoryFolder : false,
+    folderColor: templateData.folderColor ?? "#3B82F6",
+    folderIcon: templateData.folderIcon ?? "folder",
+    displayOrder: (templateData.displayOrder as number | undefined) ?? 0,
+    fieldCount: (templateData.fieldCount as number | undefined) ?? (Array.isArray(items) ? items.length : 0),
+    usageCount: (templateData.usageCount as number | undefined) ?? 0,
+    lastUsedAt: toOptionalDate(templateData.lastUsedAt) ?? null,
+    createdBy: templateData.createdBy,
+    createdAt: toOptionalDate(templateData.createdAt) ?? now,
+    updatedAt: toOptionalDate(templateData.updatedAt) ?? now
+  };
+
+  return sanitizeRecord(prepared);
+}
+
+export function prepareChecklistFolder(folder: InsertChecklistFolder): PreparedRecord {
+  const folderData = folder as Record<string, any>;
+  const now = new Date();
+
+  const prepared: PreparedRecord = {
+    id: folderData.id ?? randomUUID(),
+    name: folderData.name,
+    description: folderData.description ?? null,
+    parentId: folderData.parentId ?? null,
+    organizationId: folderData.organizationId,
+    icon: folderData.icon ?? "folder",
+    color: folderData.color ?? "#3B82F6",
+    order: (folderData.order as number | undefined) ?? 0,
+    createdBy: folderData.createdBy,
+    createdAt: toOptionalDate(folderData.createdAt) ?? now,
+    updatedAt: toOptionalDate(folderData.updatedAt) ?? now
+  };
+
+  return sanitizeRecord(prepared);
+}
+
+export function prepareActivityLog(log: InsertActivityLog): PreparedRecord {
+  const logData = log as Record<string, any>;
+  const now = new Date();
+
+  const prepared: PreparedRecord = {
+    id: logData.id ?? randomUUID(),
+    userId: logData.userId,
+    organizationId: logData.organizationId,
+    action: logData.action,
+    entityType: logData.entityType ?? null,
+    entityId: logData.entityId ?? null,
+    details: ensureObject(logData.details),
+    createdAt: toOptionalDate(logData.createdAt) ?? now
+  };
+
+  return sanitizeRecord(prepared);
+}
+
+export function prepareCompany(company: InsertCompany): PreparedRecord {
+  const companyData = company as Record<string, any>;
+  const now = new Date();
+
+  const prepared: PreparedRecord = {
+    id: companyData.id ?? randomUUID(),
+    name: companyData.name,
+    cnpj: companyData.cnpj ?? null,
+    email: companyData.email ?? null,
+    phone: companyData.phone ?? null,
+    website: companyData.website ?? null,
+    address: companyData.address ?? null,
+    city: companyData.city ?? null,
+    state: companyData.state ?? null,
+    zipCode: companyData.zipCode ?? null,
+    responsibleName: companyData.responsibleName ?? null,
+    responsibleRole: companyData.responsibleRole ?? null,
+    responsibleEmail: companyData.responsibleEmail ?? null,
+    responsiblePhone: companyData.responsiblePhone ?? null,
+    technicalResponsibleName: companyData.technicalResponsibleName ?? null,
+    technicalResponsibleRole: companyData.technicalResponsibleRole ?? null,
+    technicalResponsibleEmail: companyData.technicalResponsibleEmail ?? null,
+    technicalResponsiblePhone: companyData.technicalResponsiblePhone ?? null,
+    technicalResponsibleCertification: companyData.technicalResponsibleCertification ?? null,
+    organizationId: companyData.organizationId,
+    isActive: typeof companyData.isActive === "boolean" ? companyData.isActive : true,
+    notes: companyData.notes ?? null,
+    createdBy: companyData.createdBy,
+    createdAt: toOptionalDate(companyData.createdAt) ?? now,
+    updatedAt: toOptionalDate(companyData.updatedAt) ?? now
+  };
+
+  return sanitizeRecord(prepared);
+}
+
+export function prepareCompanyLocation(location: InsertCompanyLocation): PreparedRecord {
+  const locationData = location as Record<string, any>;
+  const now = new Date();
+  const latitude = toOptionalNumber(locationData.latitude);
+  const longitude = toOptionalNumber(locationData.longitude);
+
+  const prepared: PreparedRecord = {
+    id: locationData.id ?? randomUUID(),
+    companyId: locationData.companyId,
+    name: locationData.name,
+    type: locationData.type ?? null,
+    address: locationData.address ?? null,
+    city: locationData.city ?? null,
+    state: locationData.state ?? null,
+    zipCode: locationData.zipCode ?? null,
+    latitude: latitude ?? null,
+    longitude: longitude ?? null,
+    responsibleName: locationData.responsibleName ?? null,
+    responsiblePhone: locationData.responsiblePhone ?? null,
+    responsibleEmail: locationData.responsibleEmail ?? null,
+    isActive: typeof locationData.isActive === "boolean" ? locationData.isActive : true,
+    notes: locationData.notes ?? null,
+    createdBy: locationData.createdBy,
+    createdAt: toOptionalDate(locationData.createdAt) ?? now,
+    updatedAt: toOptionalDate(locationData.updatedAt) ?? now
+  };
+
+  return sanitizeRecord(prepared);
+}


### PR DESCRIPTION
## Summary
- add concrete implementations for storage normalizers so Drizzle inserts receive sanitized defaults
- harden front-end pages and analytics/export services with stronger typing to satisfy TypeScript checks
- adjust OpenAI assistant run polling to use the current API parameters

## Testing
- pnpm check

------
https://chatgpt.com/codex/tasks/task_e_68ca15c3791c832083ad007340c78818