### PR TITLE
Fix checklist fallback when inspection checklist is empty

### DIFF
--- a/client/src/pages/InspectionDetail.tsx
+++ b/client/src/pages/InspectionDetail.tsx
@@ -148,6 +148,10 @@ export default function InspectionDetail() {
     );
   }
 
+  const hasChecklist = Array.isArray(inspection.checklist)
+    ? inspection.checklist.length > 0
+    : Boolean(inspection.checklist);
+
   return (
     <TooltipProvider>
       <div className="p-6 max-w-6xl mx-auto" data-testid="inspection-detail-page">
@@ -353,7 +357,7 @@ export default function InspectionDetail() {
               </CardTitle>
             </CardHeader>
             <CardContent>
-              {inspection.checklist ? (
+              {hasChecklist ? (
                 <div className="space-y-4">
                   <div className="flex items-center space-x-2 p-3 bg-green-50 border border-green-200 rounded-lg">
                     <CheckCircle2 className="w-5 h-5 text-green-600" />


### PR DESCRIPTION
## Summary
- derive a hasChecklist flag that treats empty arrays as falsey
- use the derived flag when rendering the checklist section so empty templates do not show the active banner

## Testing
- `npm run check` *(fails: existing type errors in AcceptInvite.tsx, InspectionDetail.tsx params null check, Inspections.tsx, Reports.tsx, Users.tsx, server/services files, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68d298820cac8320bd7c5d1186297510